### PR TITLE
fix: align mdbook search config with u8 requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ debug/
 coverage/
 docs/completions/
 docs/man/
-docs/build/
+docs/book/

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -7,7 +7,7 @@ multilingual = false
 src = "src"
 
 [build]
-build-dir = "build"
+build-dir = "book"
 create-missing = true
 
 [output.html]


### PR DESCRIPTION
Use integer boost values so mdBook can deserialize the search config and ignore generated docs/build artifacts to keep lint clean.