### PR TITLE
ci: address zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-minor-days: 7
       semver-major-days: 30
     ignore:
@@ -26,7 +26,7 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-minor-days: 7
       semver-major-days: 30
     groups:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,8 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0


### PR DESCRIPTION
## Summary
- add the missing `security-events: write` permission to the Zizmor workflow
- disable persisted checkout credentials in the Zizmor workflow
- raise Dependabot `cooldown.default-days` from `3` to `7` for cargo and GitHub Actions updates
- leave `.github/workflows/release.yml` unchanged because it is cargo-dist managed

## Testing
- `mise run fmt`
- `mise run lint`
- `mise run test`
- `mise run coverage`
- `scripts/check_lcov_lines.sh coverage/lcov.info` (`100.00%`)
