### PR TITLE
ci: fix dependabot cooldown config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,6 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-minor-days: 7
-      semver-major-days: 30
     groups:
       all-version-updates:
         patterns:


### PR DESCRIPTION
## Summary
- remove `semver-minor-days` from the `github-actions` Dependabot cooldown block
- remove `semver-major-days` from the `github-actions` Dependabot cooldown block
- keep the cargo cooldown settings unchanged

## Why
GitHub rejected the previous config on the `github-actions` updater with:

> property semver-major-days is not allowed

This follow-up keeps the intended default cooldown while using only the fields GitHub actually accepts for that updater.

## Testing
- `mise run fmt`
- `mise run lint`
- `mise run test`
- `mise run coverage`
- `scripts/check_lcov_lines.sh coverage/lcov.info` (`100.00%`)
