### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet.
 
+## [0.10.0] - 2026-04-15
+
+<!-- markdownlint-disable-next-line MD024 -->
+### Breaking
+
+- Nothing yet.
+
+<!-- markdownlint-disable-next-line MD024 -->
+### Added
+
+- Surfaced renamed Codex session thread names near the top of the TUI list with profile-like styling, prompt context, and prioritized fuzzy matching so named sessions are easier to spot and resume.
+
+<!-- markdownlint-disable-next-line MD024 -->
+### Changed
+
+- Aligned named-session spacing and presentation with profile entries while still keeping the underlying session context visible in the browser list.
+
+<!-- markdownlint-disable-next-line MD024 -->
+### Fixed
+
+- Nothing yet.
+
 ## [0.9.0] - 2026-04-05
 
 <!-- markdownlint-disable-next-line MD024 -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,7 +3355,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tool-executor"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "tx"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ required-features = [ "benchmarks",]
 
 [package]
 name = "tool-executor"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.90"
 authors = [ "Bede Carroll <bedecarroll@users.noreply.github.com>",]

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tx"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["Bede Carroll <bedecarroll@users.noreply.github.com>"]
 description = "A thin, configurable launcher for AI code-assistant sessions"


### PR DESCRIPTION
## Summary
- bump workspace and CLI crate versions to `0.10.0`
- update `CHANGELOG.md` with `## [0.10.0] - 2026-04-15`
- refresh `Cargo.lock` package versions for `tool-executor` and `tx`
- document the renamed session thread TUI feature as the headline release note

## Testing
- `mise run fmt`
- `mise run lint`
- `mise run test`
- `mise run coverage`
