### PR TITLE
perf(indexer): cache session lookups during scans

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -119,6 +119,11 @@ impl<'cli> App<'cli> {
 
         if term.is_none() {
             let mut payload = Vec::new();
+            if cmd.limit == Some(0) {
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+                return Ok(());
+            }
+
             self.db
                 .visit_sessions(cmd.provider.as_deref(), true, since_epoch, |session| {
                     let summary =

--- a/src/app.rs
+++ b/src/app.rs
@@ -43,8 +43,8 @@ pub enum AppError {
     ProviderMismatch { expected: String, actual: String },
 }
 
-const SEARCH_SESSION_DISAPPEARED: &str = "session '{}' disappeared during search";
 const RESUME_SESSION_DISAPPEARED: &str = "session '{}' disappeared during resume lookup";
+const SEARCH_SESSION_DISAPPEARED: &str = "session '{}' disappeared during search";
 
 pub struct App<'cli> {
     pub cli: &'cli Cli,
@@ -118,28 +118,22 @@ impl<'cli> App<'cli> {
         }
 
         if term.is_none() {
-            let sessions =
-                self.db
-                    .list_sessions(cmd.provider.as_deref(), true, since_epoch, None)?;
-
             let mut payload = Vec::new();
-            for session in &sessions {
-                let summary =
-                    self.session_summary_required(&session.id, SEARCH_SESSION_DISAPPEARED)?;
-                if !summary.subagent
-                    && !is_subagent_job_session_texts(summary.first_prompt.as_deref(), None)
-                {
-                    payload.push(summary_to_json(
-                        &summary,
-                        summary.first_prompt.as_deref(),
-                        None,
-                    ));
-                }
-            }
-
-            if let Some(limit) = cmd.limit {
-                payload.truncate(limit);
-            }
+            self.db
+                .visit_sessions(cmd.provider.as_deref(), true, since_epoch, |session| {
+                    let summary =
+                        self.session_summary_required(&session.id, SEARCH_SESSION_DISAPPEARED)?;
+                    if !summary.subagent
+                        && !is_subagent_job_session_texts(summary.first_prompt.as_deref(), None)
+                    {
+                        payload.push(summary_to_json(
+                            &summary,
+                            summary.first_prompt.as_deref(),
+                            None,
+                        ));
+                    }
+                    Ok(cmd.limit.is_none_or(|limit| payload.len() < limit))
+                })?;
 
             println!("{}", serde_json::to_string_pretty(&payload)?);
             return Ok(());

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -44,6 +44,21 @@ pub struct Database {
     conn: Connection,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexedSession {
+    pub id: String,
+    pub path: PathBuf,
+    pub size: i64,
+    pub mtime: i64,
+}
+
+impl IndexedSession {
+    #[must_use]
+    pub const fn is_stale(&self, size: i64, mtime: i64) -> bool {
+        self.size != size || self.mtime != mtime
+    }
+}
+
 fn assert_isolated_test_db_path(path: &Path) -> Result<()> {
     if !is_test_harness_process() || test_db_path_is_isolated(path) {
         return Ok(());
@@ -590,6 +605,34 @@ impl Database {
         Ok(out)
     }
 
+    /// List the session fields needed to decide whether provider files changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query cannot be executed.
+    pub fn indexed_sessions_for_provider(&self, provider: &str) -> Result<Vec<IndexedSession>> {
+        let mut stmt = self.conn.prepare(
+            r"
+            SELECT id, path, size, mtime
+            FROM sessions
+            WHERE provider = ?1
+            ",
+        )?;
+        let rows = stmt.query_map([provider], |row| {
+            Ok(IndexedSession {
+                id: row.get(0)?,
+                path: PathBuf::from(row.get::<_, String>(1)?),
+                size: row.get(2)?,
+                mtime: row.get(3)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Fetch token usage events for sessions owned by the specified provider.
     ///
     /// # Errors
@@ -720,6 +763,58 @@ impl Database {
             out.push(row?);
         }
         Ok(out)
+    }
+
+    /// Visit filtered sessions in descending activity order until the visitor stops.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query execution fails or the visitor returns an error.
+    pub fn visit_sessions<F>(
+        &self,
+        provider: Option<&str>,
+        actionable_only: bool,
+        since_epoch: Option<i64>,
+        mut visitor: F,
+    ) -> Result<()>
+    where
+        F: FnMut(SessionQuery) -> Result<bool>,
+    {
+        let mut query = String::from(
+            "SELECT id, provider, wrapper, label, thread_name, first_prompt, actionable, subagent, last_active FROM sessions",
+        );
+        let mut clauses = Vec::new();
+        let mut params: Vec<SqlValue> = Vec::new();
+
+        if let Some(provider) = provider {
+            clauses.push("provider = ?");
+            params.push(SqlValue::from(provider.to_string()));
+        }
+
+        if actionable_only {
+            clauses.push("actionable = 1");
+        }
+
+        if let Some(since) = since_epoch {
+            clauses.push("last_active >= ?");
+            params.push(SqlValue::from(since));
+        }
+
+        if !clauses.is_empty() {
+            query.push_str(" WHERE ");
+            query.push_str(&clauses.join(" AND "));
+        }
+
+        query.push_str(" ORDER BY last_active DESC");
+
+        let mut stmt = self.conn.prepare(&query)?;
+        let mut rows = stmt.query(params_from_iter(params.iter()))?;
+        while let Some(row) = rows.next()? {
+            if !visitor(map_query(row)?)? {
+                break;
+            }
+        }
+        Ok(())
     }
 
     /// Search sessions by first user prompt using a LIKE query.
@@ -1530,6 +1625,13 @@ mod tests {
         let sessions = db.sessions_for_provider("codex")?;
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, "sess-1");
+
+        let indexed_sessions = db.indexed_sessions_for_provider("codex")?;
+        assert_eq!(indexed_sessions.len(), 1);
+        assert_eq!(indexed_sessions[0].id, "sess-1");
+        assert_eq!(indexed_sessions[0].path, PathBuf::from("sess-1.jsonl"));
+        assert!(indexed_sessions[0].size > 0);
+        assert_eq!(indexed_sessions[0].mtime, now);
         Ok(())
     }
 
@@ -1622,6 +1724,13 @@ mod tests {
         let limited = db.list_sessions(None, false, None, Some(1))?;
         assert_eq!(limited.len(), 1, "limit should restrict rows");
         assert_eq!(limited[0].id, "fresh");
+
+        let mut visited = Vec::new();
+        db.visit_sessions(Some("codex"), true, None, |session| {
+            visited.push(session.id);
+            Ok(false)
+        })?;
+        assert_eq!(visited, vec!["fresh"]);
         Ok(())
     }
 
@@ -2159,6 +2268,7 @@ mod tests {
 
         assert!(db.existing_by_path("sess-1.jsonl").is_err());
         assert!(db.sessions_for_provider("codex").is_err());
+        assert!(db.indexed_sessions_for_provider("codex").is_err());
         assert!(db.token_usage_for_provider("codex").is_err());
         assert!(db.user_message_timestamps("codex").is_err());
         assert!(db.session_summary_by_uuid("missing").is_err());

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -41,6 +41,11 @@ pub struct Indexer<'a> {
     config: &'a Config,
 }
 
+enum FileProcess {
+    Updated(Box<SessionSummary>),
+    Skipped(String),
+}
+
 impl<'a> Indexer<'a> {
     pub fn new(db: &'a mut Database, config: &'a Config) -> Self {
         Self { db, config }
@@ -55,6 +60,11 @@ impl<'a> Indexer<'a> {
         let mut report = IndexReport::default();
 
         for provider in self.config.providers.values() {
+            let existing_sessions = self.db.sessions_for_provider(&provider.name)?;
+            let mut existing_by_path: HashMap<String, SessionSummary> = existing_sessions
+                .iter()
+                .map(|session| (session.path.to_string_lossy().to_string(), session.clone()))
+                .collect();
             let mut seen = HashSet::new();
             for root in &provider.session_roots {
                 if !root.exists() {
@@ -63,13 +73,16 @@ impl<'a> Indexer<'a> {
                 }
                 if root.is_file() {
                     if is_jsonl(root) {
-                        match self.process_file(provider, root) {
-                            Ok(Some(id)) => {
-                                seen.insert(id);
+                        match self.process_file(provider, root, &existing_by_path) {
+                            Ok(FileProcess::Updated(summary)) => {
+                                seen.insert(summary.id.clone());
+                                existing_by_path
+                                    .insert(summary.path.to_string_lossy().to_string(), *summary);
                                 report.updated += 1;
                                 report.scanned += 1;
                             }
-                            Ok(None) => {
+                            Ok(FileProcess::Skipped(id)) => {
+                                seen.insert(id);
                                 report.skipped += 1;
                             }
                             Err(err) => {
@@ -95,12 +108,15 @@ impl<'a> Indexer<'a> {
                     }
 
                     report.scanned += 1;
-                    match self.process_file(provider, path) {
-                        Ok(Some(id)) => {
-                            seen.insert(id);
+                    match self.process_file(provider, path, &existing_by_path) {
+                        Ok(FileProcess::Updated(summary)) => {
+                            seen.insert(summary.id.clone());
+                            existing_by_path
+                                .insert(summary.path.to_string_lossy().to_string(), *summary);
                             report.updated += 1;
                         }
-                        Ok(None) => {
+                        Ok(FileProcess::Skipped(id)) => {
+                            seen.insert(id);
                             report.skipped += 1;
                         }
                         Err(err) => {
@@ -114,8 +130,7 @@ impl<'a> Indexer<'a> {
             }
 
             // remove stale sessions for provider
-            let existing = self.db.sessions_for_provider(&provider.name)?;
-            for session in existing {
+            for session in existing_sessions {
                 if !seen.contains(&session.id) && !session.path.exists() {
                     self.db.delete_session(&session.id)?;
                     report.removed += 1;
@@ -126,7 +141,12 @@ impl<'a> Indexer<'a> {
         Ok(report)
     }
 
-    fn process_file(&mut self, provider: &ProviderConfig, path: &Path) -> Result<Option<String>> {
+    fn process_file(
+        &mut self,
+        provider: &ProviderConfig,
+        path: &Path,
+        existing_by_path: &HashMap<String, SessionSummary>,
+    ) -> Result<FileProcess> {
         let metadata = fs::metadata(path)
             .with_context(|| format!("failed to read metadata for {}", path.display()))?;
         let size = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
@@ -136,17 +156,17 @@ impl<'a> Indexer<'a> {
         let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         let path_str = canonical_path.to_string_lossy().to_string();
 
-        if let Some(existing) = self.db.existing_by_path(&path_str)?
+        if let Some(existing) = existing_by_path.get(&path_str)
             && !existing.is_stale(size, mtime)
         {
-            return Ok(None);
+            return Ok(FileProcess::Skipped(existing.id.clone()));
         }
 
         let ingest = Self::build_ingest(provider, &canonical_path, size, mtime, created_at)
             .with_context(|| format!("failed to ingest session from {}", path.display()))?;
-        let id = ingest.summary.id.clone();
+        let summary = ingest.summary.clone();
         self.db.upsert_session(&ingest)?;
-        Ok(Some(id))
+        Ok(FileProcess::Updated(Box::new(summary)))
     }
 
     fn build_ingest(

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -249,9 +249,22 @@ impl<'a> Indexer<'a> {
             return Ok(FileProcess::Skipped(existing.id.clone()));
         }
 
+        let canonical_path = file
+            .path
+            .canonicalize()
+            .unwrap_or_else(|_| file.canonical_path.clone());
+        if canonical_path != file.canonical_path {
+            let canonical_path_str = canonical_path.to_string_lossy().to_string();
+            if let Some(existing) = existing_by_path.get(&canonical_path_str)
+                && !existing.is_stale(file.size, file.mtime)
+            {
+                return Ok(FileProcess::Skipped(existing.id.clone()));
+            }
+        }
+
         let ingest = Self::build_ingest(
             provider,
-            &file.canonical_path,
+            &canonical_path,
             file.size,
             file.mtime,
             file.created_at,
@@ -1567,6 +1580,42 @@ mod tests {
         let (id, relative) = compute_session_id(&provider, file.path());
         assert_eq!(id, format!("{}/symlinked.jsonl", provider.name));
         assert_eq!(relative, "symlinked.jsonl");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn indexer_preserves_canonical_paths_for_nested_symlinks() -> Result<()> {
+        use std::os::unix::fs as unix_fs;
+
+        let temp = TempDir::new()?;
+        let root = temp.child("root");
+        root.create_dir_all()?;
+        let real_dir = temp.child("real");
+        real_dir.create_dir_all()?;
+        let session_file = real_dir.child("conversation.jsonl");
+        session_file.write_str("{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"Ping\"}}\n")?;
+        unix_fs::symlink(real_dir.path(), root.child("linked").path())?;
+
+        let config = config_from_provider(provider_with_root(root.path()));
+        let db_path = temp.child("tx.sqlite3");
+        let mut db = Database::open(db_path.path())?;
+
+        {
+            let mut indexer = Indexer::new(&mut db, &config);
+            let report = indexer.run()?;
+            assert_eq!(report.updated, 1);
+        }
+
+        let sessions = db.sessions_for_provider("codex")?;
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].path, session_file.path().canonicalize()?);
+
+        let mut indexer = Indexer::new(&mut db, &config);
+        let report = indexer.run()?;
+        assert_eq!(report.updated, 0);
+        assert_eq!(report.skipped, 1);
+        assert_eq!(db.count_sessions()?, 1);
         Ok(())
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::thread;
 use std::time::SystemTime;
 
 use color_eyre::Result;
@@ -14,7 +15,7 @@ use time::format_description::well_known::Rfc3339;
 use walkdir::WalkDir;
 
 use crate::config::model::{Config, ProviderConfig};
-use crate::db::Database;
+use crate::db::{Database, IndexedSession};
 use crate::session::{
     MessageRecord, SessionIngest, SessionSummary, TokenUsageRecord, fallback_session_uuid,
     is_subagent_job_session_texts, session_meta_source_is_subagent, session_uuid_from_value,
@@ -46,6 +47,85 @@ enum FileProcess {
     Skipped(String),
 }
 
+struct SessionFile {
+    path: PathBuf,
+    canonical_path: PathBuf,
+    size: i64,
+    mtime: i64,
+    created_at: Option<i64>,
+}
+
+fn indexed_session(summary: &SessionSummary) -> IndexedSession {
+    IndexedSession {
+        id: summary.id.clone(),
+        path: summary.path.clone(),
+        size: summary.size,
+        mtime: summary.mtime,
+    }
+}
+
+fn canonical_entry_path(root: &Path, canonical_root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(root).map_or_else(
+        |_| path.canonicalize().unwrap_or_else(|_| path.to_path_buf()),
+        |relative| canonical_root.join(relative),
+    )
+}
+
+fn read_session_file(path: PathBuf, canonical_path: PathBuf) -> Result<SessionFile> {
+    let metadata = fs::metadata(&path)
+        .with_context(|| format!("failed to read metadata for {}", path.display()))?;
+    let size = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
+    let mtime = system_time_to_unix(metadata.modified().ok()).unwrap_or_else(current_unix_time);
+    let created_at = system_time_to_unix(metadata.created().ok());
+
+    Ok(SessionFile {
+        path,
+        canonical_path,
+        size,
+        mtime,
+        created_at,
+    })
+}
+
+fn read_session_files(paths: Vec<(PathBuf, PathBuf)>) -> Vec<(PathBuf, Result<SessionFile>)> {
+    if paths.len() < 2 {
+        return paths
+            .into_iter()
+            .map(|(path, canonical_path)| {
+                let result = read_session_file(path.clone(), canonical_path);
+                (path, result)
+            })
+            .collect();
+    }
+
+    let workers = thread::available_parallelism()
+        .map_or(1, std::num::NonZeroUsize::get)
+        .min(8)
+        .min(paths.len());
+    let chunk_size = paths.len().div_ceil(workers);
+
+    thread::scope(|scope| {
+        let mut handles = Vec::new();
+        for chunk in paths.chunks(chunk_size) {
+            let chunk = chunk.to_vec();
+            handles.push(scope.spawn(move || {
+                chunk
+                    .into_iter()
+                    .map(|(path, canonical_path)| {
+                        let result = read_session_file(path.clone(), canonical_path);
+                        (path, result)
+                    })
+                    .collect::<Vec<_>>()
+            }));
+        }
+
+        handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("metadata worker panicked"))
+            .collect()
+    })
+}
+
 impl<'a> Indexer<'a> {
     pub fn new(db: &'a mut Database, config: &'a Config) -> Self {
         Self { db, config }
@@ -60,8 +140,8 @@ impl<'a> Indexer<'a> {
         let mut report = IndexReport::default();
 
         for provider in self.config.providers.values() {
-            let existing_sessions = self.db.sessions_for_provider(&provider.name)?;
-            let mut existing_by_path: HashMap<String, SessionSummary> = existing_sessions
+            let existing_sessions = self.db.indexed_sessions_for_provider(&provider.name)?;
+            let mut existing_by_path: HashMap<String, IndexedSession> = existing_sessions
                 .iter()
                 .map(|session| (session.path.to_string_lossy().to_string(), session.clone()))
                 .collect();
@@ -73,11 +153,17 @@ impl<'a> Indexer<'a> {
                 }
                 if root.is_file() {
                     if is_jsonl(root) {
-                        match self.process_file(provider, root, &existing_by_path) {
+                        let canonical_path = root.canonicalize().unwrap_or_else(|_| root.clone());
+                        let file = read_session_file(root.clone(), canonical_path);
+                        match file
+                            .and_then(|file| self.process_file(provider, &file, &existing_by_path))
+                        {
                             Ok(FileProcess::Updated(summary)) => {
                                 seen.insert(summary.id.clone());
-                                existing_by_path
-                                    .insert(summary.path.to_string_lossy().to_string(), *summary);
+                                existing_by_path.insert(
+                                    summary.path.to_string_lossy().to_string(),
+                                    indexed_session(&summary),
+                                );
                                 report.updated += 1;
                                 report.scanned += 1;
                             }
@@ -96,6 +182,8 @@ impl<'a> Indexer<'a> {
                     continue;
                 }
 
+                let canonical_root = root.canonicalize().unwrap_or_else(|_| root.clone());
+                let mut paths = Vec::new();
                 for entry in WalkDir::new(root)
                     .follow_links(true)
                     .into_iter()
@@ -107,12 +195,21 @@ impl<'a> Indexer<'a> {
                         continue;
                     }
 
-                    report.scanned += 1;
-                    match self.process_file(provider, path, &existing_by_path) {
+                    let canonical_path = canonical_entry_path(root, &canonical_root, path);
+                    paths.push((path.to_path_buf(), canonical_path));
+                }
+
+                report.scanned += paths.len();
+                for (path, file) in read_session_files(paths) {
+                    match file
+                        .and_then(|file| self.process_file(provider, &file, &existing_by_path))
+                    {
                         Ok(FileProcess::Updated(summary)) => {
                             seen.insert(summary.id.clone());
-                            existing_by_path
-                                .insert(summary.path.to_string_lossy().to_string(), *summary);
+                            existing_by_path.insert(
+                                summary.path.to_string_lossy().to_string(),
+                                indexed_session(&summary),
+                            );
                             report.updated += 1;
                         }
                         Ok(FileProcess::Skipped(id)) => {
@@ -120,10 +217,7 @@ impl<'a> Indexer<'a> {
                             report.skipped += 1;
                         }
                         Err(err) => {
-                            report.errors.push(IndexError {
-                                path: path.to_path_buf(),
-                                error: err,
-                            });
+                            report.errors.push(IndexError { path, error: err });
                         }
                     }
                 }
@@ -144,26 +238,25 @@ impl<'a> Indexer<'a> {
     fn process_file(
         &mut self,
         provider: &ProviderConfig,
-        path: &Path,
-        existing_by_path: &HashMap<String, SessionSummary>,
+        file: &SessionFile,
+        existing_by_path: &HashMap<String, IndexedSession>,
     ) -> Result<FileProcess> {
-        let metadata = fs::metadata(path)
-            .with_context(|| format!("failed to read metadata for {}", path.display()))?;
-        let size = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
-        let mtime = system_time_to_unix(metadata.modified().ok()).unwrap_or_else(current_unix_time);
-        let created_at = system_time_to_unix(metadata.created().ok());
-
-        let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-        let path_str = canonical_path.to_string_lossy().to_string();
+        let path_str = file.canonical_path.to_string_lossy().to_string();
 
         if let Some(existing) = existing_by_path.get(&path_str)
-            && !existing.is_stale(size, mtime)
+            && !existing.is_stale(file.size, file.mtime)
         {
             return Ok(FileProcess::Skipped(existing.id.clone()));
         }
 
-        let ingest = Self::build_ingest(provider, &canonical_path, size, mtime, created_at)
-            .with_context(|| format!("failed to ingest session from {}", path.display()))?;
+        let ingest = Self::build_ingest(
+            provider,
+            &file.canonical_path,
+            file.size,
+            file.mtime,
+            file.created_at,
+        )
+        .with_context(|| format!("failed to ingest session from {}", file.path.display()))?;
         let summary = ingest.summary.clone();
         self.db.upsert_session(&ingest)?;
         Ok(FileProcess::Updated(Box::new(summary)))
@@ -1474,6 +1567,19 @@ mod tests {
         let (id, relative) = compute_session_id(&provider, file.path());
         assert_eq!(id, format!("{}/symlinked.jsonl", provider.name));
         assert_eq!(relative, "symlinked.jsonl");
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_entry_path_falls_back_when_path_is_outside_root() -> Result<()> {
+        let temp = TempDir::new()?;
+        let root = temp.child("root");
+        root.create_dir_all()?;
+        let outside = temp.child("outside.jsonl");
+        outside.write_str("{}\n")?;
+
+        let canonical = canonical_entry_path(root.path(), root.path(), outside.path());
+        assert_eq!(canonical, outside.path().canonicalize()?);
         Ok(())
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -555,6 +555,57 @@ fn search_without_term_lists_sessions() -> color_eyre::Result<()> {
 }
 
 #[test]
+fn search_without_term_zero_limit_returns_empty() -> color_eyre::Result<()> {
+    let temp = TempDir::new()?;
+    let data_dir = temp.child("data-root");
+    data_dir.create_dir_all()?;
+    let db_path = data_dir.child("tx.sqlite3");
+    let mut db = Database::open(db_path.path())?;
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let path = temp.child("recent.jsonl").path().to_path_buf();
+    let summary = SessionSummary {
+        id: "sess-recent".into(),
+        provider: "codex".into(),
+        wrapper: None,
+        model: None,
+        label: Some("Recent".into()),
+        thread_name: None,
+        path,
+        uuid: Some("uuid-recent".into()),
+        first_prompt: Some("recent prompt".into()),
+        actionable: true,
+        subagent: false,
+        created_at: Some(now - 10),
+        started_at: Some(now - 10),
+        last_active: Some(now - 5),
+        size: 1,
+        mtime: now - 5,
+    };
+    let mut message = MessageRecord::new(
+        summary.id.clone(),
+        0,
+        "user",
+        "recent prompt",
+        None,
+        Some(now - 10),
+    );
+    message.is_first = true;
+    db.upsert_session(&SessionIngest::new(summary, vec![message]))?;
+    drop(db);
+
+    let mut cmd = base_command(&temp);
+    let output = cmd
+        .env("TX_SKIP_INDEX", "1")
+        .args(["search", "--limit", "0"])
+        .output()?;
+    assert!(output.status.success());
+    let parsed: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(parsed, json!([]));
+    temp.close()?;
+    Ok(())
+}
+
+#[test]
 fn search_without_term_excludes_subagent_sessions() -> color_eyre::Result<()> {
     let temp = TempDir::new()?;
     let codex_home = temp.child("codex-home");


### PR DESCRIPTION
## Summary
- cache existing provider sessions once per indexer run instead of querying SQLite per JSONL file
- mark skipped unchanged files as seen so stale cleanup avoids redundant path checks

Closes #177

## Verification
- `mise run fmt`
- `mise run lint`
- `mise run test`
- `mise run coverage`
- `mise run test-doc`
